### PR TITLE
Rename Secret to be Disk specific

### DIFF
--- a/assets/controller.yaml
+++ b/assets/controller.yaml
@@ -281,4 +281,4 @@ spec:
             secretName: alibaba-disk-csi-driver-controller-metrics-serving-cert
         - name: credentials
           secret:
-            secretName: alibaba-cloud-credentials
+            secretName: alibaba-disk-credentials


### PR DESCRIPTION
In case we introduce other CSI drivers in the future, they should have their own Secrets.

Ref https://github.com/openshift/cluster-storage-operator/pull/238/

cc @openshift/storage 