### PR TITLE
Bug 2038021: Add a default VolumeSnapshotClass

### DIFF
--- a/assets/volumesnapshotclass.yaml
+++ b/assets/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: alicloud-disk
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: diskplugin.csi.alibabacloud.com
+deletionPolicy: Delete

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -69,6 +69,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"controller_pdb.yaml",
 			"node_sa.yaml",
 			"service.yaml",
+			"volumesnapshotclass.yaml",
 			"rbac/attacher_role.yaml",
 			"rbac/attacher_binding.yaml",
 			"rbac/privileged_role.yaml",


### PR DESCRIPTION
Deploy a default snapshot class during installation, named `alicloud-disk`.

cc @openshift/storage 