### PR TITLE
Disable snapshot tests

### DIFF
--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -23,6 +23,8 @@ DriverInfo:
     volumeLimits: false
     controllerExpansion: true
     nodeExpansion: true
-    snapshotDataSource: true
+    # Alibaba can take a snapshot of attached volume only, our tests try to take snapshot of unattached ones.
+    # It times out with "CreateSnapshot:: target disk: d-0xid8nzf2kqhzevjr9c1 must be attached"
+    snapshotDataSource: false
     topology: true
     multipods: true


### PR DESCRIPTION
Alibaba does not support snapshots of un-attached volumes and our tests need that.

cc @openshift/storage 