### PR TITLE
Bug 2058716: Add test manifests + Dockerfile for it

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,5 @@
+# "src" is build by a prow job when building final images.
+# It contains full repository sources + jq + pyhon with yaml module.
+# Use it as test image for the operator.
+
+FROM src

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -1,0 +1,28 @@
+# Test manifest for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/storage/external
+ShortName: alicloud-disk
+StorageClass:
+  FromExistingClassName: alicloud-disk
+SnapshotClass:
+  FromName: true
+DriverInfo:
+  Name: diskplugin.csi.alibabacloud.com
+  SupportedSizeRange:
+    Min: 20Gi
+    Max: 16Ti
+  SupportedFsType:
+    xfs: {}
+    ext4: {}
+  SupportedMountOption:
+    dirsync: {}
+  TopologyKeys: ["topology.diskplugin.csi.alibabacloud.com/zone"]
+  Capabilities:
+    persistence: true
+    fsGroup: true
+    block: true
+    exec: true
+    volumeLimits: false
+    controllerExpansion: true
+    nodeExpansion: true
+    snapshotDataSource: true
+    topology: true
+    multipods: true

--- a/test/e2e/manifest.yaml
+++ b/test/e2e/manifest.yaml
@@ -23,6 +23,8 @@ DriverInfo:
     volumeLimits: false
     controllerExpansion: true
     nodeExpansion: true
-    snapshotDataSource: true
+    # Alibaba can take a snapshot of attached volume only, our tests try to take snapshot of unattached ones.
+    # It times out with "CreateSnapshot:: target disk: d-0xid8nzf2kqhzevjr9c1 must be attached"
+    snapshotDataSource: false
     topology: true
     multipods: true


### PR DESCRIPTION
Add manifest.yaml and Dockerfile.test with it. This manifest + image will be used in CI to run CSI tests.

These are direct cherry-picks from master.