### PR TITLE
Bug 2096691: Add resourceGroupID to StorageClass parameters 

### DIFF
--- a/assets/storageclass.yaml
+++ b/assets/storageclass.yaml
@@ -8,6 +8,7 @@ provisioner: diskplugin.csi.alibabacloud.com
 parameters:
   type: available
   volumeSizeAutoAvailable: "true"
+  # resourceGroupID will be added by the operator when necessary.
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/openshift/alibaba-disk-csi-driver-operator
 go 1.17
 
 require (
+	github.com/google/go-cmp v0.5.6
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
 	github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
-	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
+	github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.4.0
+	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
 	k8s.io/component-base v0.24.0
@@ -38,7 +40,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
@@ -93,7 +94,6 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.24.0 // indirect
 	k8s.io/apiextensions-apiserver v0.24.0 // indirect
 	k8s.io/apiserver v0.24.0 // indirect
 	k8s.io/kube-aggregator v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,8 +520,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3 h1:M7
 github.com/openshift/build-machinery-go v0.0.0-20220429084610-baff9f8d23b3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a h1:ylsEgoC8Dlg4A0C1TLH0A4x/TZao7k1YveLwROhRUdk=
 github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a/go.mod h1:eDO5QeVi2IiXmDwB0e2z1DpAznWroZKe978pzZwFBzg=
-github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
-github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
+github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c h1:Z0uVzdNHQfbCpP498tAE53sh84ILdOj4H1LyJv465c8=
+github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/openshift/alibaba-disk-csi-driver-operator/assets"
-	"github.com/openshift/library-go/pkg/controller/factory"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -16,6 +15,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/csi/csicontrollerset"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivernodeservicecontroller"
@@ -24,12 +24,14 @@ import (
 )
 
 const (
-	defaultNamespace   = "openshift-cluster-csi-drivers"
-	operatorName       = "alibaba-cloud-csi-driver-operator"
-	operandName        = "alibaba-cloud-csi-driver"
-	instanceName       = "diskplugin.csi.alibabacloud.com"
-	secretName         = "alibaba-cloud-credentials"
-	trustedCAConfigMap = "alibaba-disk-csi-driver-trusted-ca-bundle"
+	defaultNamespace     = "openshift-cluster-csi-drivers"
+	operatorName         = "alibaba-cloud-csi-driver-operator"
+	operandName          = "alibaba-cloud-csi-driver"
+	instanceName         = "diskplugin.csi.alibabacloud.com"
+	secretName           = "alibaba-cloud-credentials"
+	trustedCAConfigMap   = "alibaba-disk-csi-driver-trusted-ca-bundle"
+	infrastructureName   = "cluster"
+	resourceGroupIDParam = "resourceGroupID"
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {
@@ -131,6 +133,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		"storageclass.yaml",
 		kubeClient,
 		kubeInformersForNamespaces.InformersFor(""),
+		getResourceGroupHook(infraInformer.Lister()),
 	)
 	if err != nil {
 		return err

--- a/pkg/operator/storageclasshook.go
+++ b/pkg/operator/storageclasshook.go
@@ -1,0 +1,37 @@
+package operator
+
+import (
+	"fmt"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	infralisterv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/csi/csistorageclasscontroller"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/klog/v2"
+)
+
+func getResourceGroupHook(infraLister infralisterv1.InfrastructureLister) csistorageclasscontroller.StorageClassHookFunc {
+	return func(_ *opv1.OperatorSpec, class *storagev1.StorageClass) error {
+		infra, err := infraLister.Get(infrastructureName)
+		if err != nil {
+			return err
+		}
+		if infra.Status.PlatformStatus == nil {
+			return fmt.Errorf("error parsing infrastructure.status: platformStatus is nil")
+		}
+		if infra.Status.PlatformStatus.AlibabaCloud == nil {
+			return fmt.Errorf("error parsing infrastructure.status: platformStatus.alibabaCloud is nil")
+		}
+		if infra.Status.PlatformStatus.AlibabaCloud.ResourceGroupID != "" {
+			resourceGroupID := infra.Status.PlatformStatus.AlibabaCloud.ResourceGroupID
+			klog.V(4).Infof("Using resourceGroupID %q", resourceGroupID)
+			if class.Parameters == nil {
+				class.Parameters = map[string]string{}
+			}
+			class.Parameters[resourceGroupIDParam] = resourceGroupID
+			return nil
+		}
+		klog.V(4).Infof("Using no resourceGroupID")
+		return nil
+	}
+}

--- a/pkg/operator/storageclasshook_test.go
+++ b/pkg/operator/storageclasshook_test.go
@@ -1,0 +1,118 @@
+package operator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func withParameters(sc *storagev1.StorageClass, keysAndValues ...string) *storagev1.StorageClass {
+	for i := 0; i < len(keysAndValues); i += 2 {
+		sc.Parameters[keysAndValues[i]] = keysAndValues[i+1]
+	}
+	return sc
+}
+
+func sc() *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: nil,
+		},
+		Parameters: map[string]string{
+			"type":                    "available",
+			"volumeSizeAutoAvailable": "true",
+		},
+		Provisioner: "diskplugin.csi.alibabacloud.com",
+	}
+}
+
+func TestStorageClassHook(t *testing.T) {
+	tests := []struct {
+		name        string
+		infra       *configv1.Infrastructure
+		expectedSC  *storagev1.StorageClass
+		expectError bool
+	}{
+		{
+			name: "no resourceGroupID",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						AlibabaCloud: &configv1.AlibabaCloudPlatformStatus{
+							ResourceGroupID: "",
+						},
+					},
+				},
+			},
+			expectedSC: sc(),
+		},
+		{
+			name: "unsupported cloud",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						AWS: &configv1.AWSPlatformStatus{},
+					},
+				},
+			},
+			expectError: true,
+			expectedSC:  sc(),
+		},
+		{
+			name: "resourceGroupID set",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: &configv1.PlatformStatus{
+						AlibabaCloud: &configv1.AlibabaCloudPlatformStatus{
+							ResourceGroupID: "myID",
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectedSC:  withParameters(sc(), "resourceGroupID", "myID"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			infraLister := &fakeInfraLister{test.infra}
+			hook := getResourceGroupHook(infraLister)
+			testSC := sc()
+
+			err := hook(nil, testSC)
+
+			if err != nil && !test.expectError {
+				t.Errorf("got unexpected error: %s", err)
+			}
+			if err == nil && test.expectError {
+				t.Errorf("expected error, got none")
+			}
+			if !equality.Semantic.DeepEqual(test.expectedSC, testSC) {
+				t.Errorf("Unexpected StorageClass content:\n%s", cmp.Diff(test.expectedSC, testSC))
+			}
+		})
+	}
+}
+
+type fakeInfraLister struct {
+	infra *configv1.Infrastructure
+}
+
+func (f fakeInfraLister) List(selector labels.Selector) (ret []*configv1.Infrastructure, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f fakeInfraLister) Get(name string) (*configv1.Infrastructure, error) {
+	if name != "cluster" {
+		return nil, fmt.Errorf("Infrastructure %q not found", name)
+	}
+	return f.infra, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/csicontrollerset/csi_controller_set.go
@@ -222,6 +222,7 @@ func (c *CSIControllerSet) WithStorageClassController(
 	file string,
 	kubeClient kubernetes.Interface,
 	namespacedInformerFactory informers.SharedInformerFactory,
+	hooks ...csistorageclasscontroller.StorageClassHookFunc,
 ) *CSIControllerSet {
 	c.csiStorageclassController = csistorageclasscontroller.NewCSIStorageClassController(
 		name,
@@ -231,6 +232,7 @@ func (c *CSIControllerSet) WithStorageClassController(
 		namespacedInformerFactory,
 		c.operatorClient,
 		c.eventRecorder,
+		hooks...,
 	)
 	return c
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,7 +227,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
+# github.com/openshift/library-go v0.0.0-20220615161831-8b2df431789c
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
We want all PVs provisioned in the same resource group as the rest of cluster resources like VMs and their root disks.


~WIP: https://github.com/openshift/library-go/pull/1377 must be merged first and then vendored here.~