### PR TITLE
Bug 2096691: Fix typo in resourceGroupId param

### DIFF
--- a/assets/storageclass.yaml
+++ b/assets/storageclass.yaml
@@ -8,7 +8,7 @@ provisioner: diskplugin.csi.alibabacloud.com
 parameters:
   type: available
   volumeSizeAutoAvailable: "true"
-  # resourceGroupID will be added by the operator when necessary.
+  # resourceGroupId will be added by the operator when necessary.
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -31,7 +31,7 @@ const (
 	secretName           = "alibaba-cloud-credentials"
 	trustedCAConfigMap   = "alibaba-disk-csi-driver-trusted-ca-bundle"
 	infrastructureName   = "cluster"
-	resourceGroupIDParam = "resourceGroupID"
+	resourceGroupIDParam = "resourceGroupId"
 )
 
 func RunOperator(ctx context.Context, controllerConfig *controllercmd.ControllerContext) error {

--- a/pkg/operator/storageclasshook_test.go
+++ b/pkg/operator/storageclasshook_test.go
@@ -76,7 +76,7 @@ func TestStorageClassHook(t *testing.T) {
 				},
 			},
 			expectError: false,
-			expectedSC:  withParameters(sc(), "resourceGroupID", "myID"),
+			expectedSC:  withParameters(sc(), "resourceGroupId", "myID"),
 		},
 	}
 


### PR DESCRIPTION
The driver is case sensitive and requires resourceGroupId.

cc @openshift/storage 