### PR TITLE
STOR-1714: Release leadership on SIGTERM

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,7 +2,6 @@ package operator
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/openshift/alibaba-disk-csi-driver-operator/assets"
@@ -186,5 +185,5 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	go csiControllerSet.Run(ctx, 1)
 	<-ctx.Done()
 
-	return fmt.Errorf("stopped")
+	return nil
 }


### PR DESCRIPTION
When `RunOperator()` returns no error, library-go waits for leader election goroutine to release the leadership before exiting.

An error returned from `RunOperator()` takes a shortcut and leads to much faster `exit(1)`, not giving the election goroutine time to release its lease. A subsequent operator pod needs to wait for the old lease to expire, which slows down cluster upgrade and any development / debugging that needs the operator restarted.

cc @openshift/storage 